### PR TITLE
fix typos in props description

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ _The MonthPicker and the MonthPickerInput shares the same props and events._
 | months                        | Array	          | []          | Custom months if language is unsupported.|
 | default-month                 | Integer         |             | The default selected month of the month picker. To show the month picker unselected, use the no-default prop.                                 																			 |
 | default-year                  | Integer 		  | 					  | The default year of the month picker.    |
-| input-pre-filled              | Boolean 		  | 					  | The default year of the month picker.    |
-| no-default		            | Boolean         | false       | Show the month and the year defined as a value on input. It works only if the parameters default-year and default-month are defined        |
+| input-pre-filled              | Boolean 		  | 					  | Show the month and the year defined as a value on input. It works only if the parameters default-year and default-month are defined    |
+| no-default		            | Boolean         | false       | Show the month picker unselected.        |
 | show-year                     | Boolean         | false       | Show the year picker. 					         |
 | editable-year									  | Boolean					| false				| Year appears as a input field.					 |
 | clearable										  | Boolean					| false				| Possible to clear the chosen month.			 |


### PR DESCRIPTION
default-year and input-pre-filled has the same description