### PR TITLE
option to visually highlight the current month and year combination

### DIFF
--- a/example/App.vue
+++ b/example/App.vue
@@ -42,6 +42,15 @@
         </label>
 
         <label class="form__label">
+          highlight-exact-date
+          <input
+            v-model="highlightExactDate"
+            class="form__input"
+            type="checkbox"
+          />
+        </label>
+
+        <label class="form__label">
           clearable
           <input v-model="isClearable" class="form__input" type="checkbox" />
         </label>
@@ -121,6 +130,7 @@
         :editable-year="isEditableYear"
         :variant="selectedVariant"
         :show-year="showYear"
+        :highlight-exact-date="highlightExactDate"
         :max-date="maxDate !== null ? new Date(maxDate) : null"
         :min-date="minDate !== null ? new Date(minDate) : null"
         :year-only="isYearOnly"
@@ -140,6 +150,7 @@
         :editable-year="isEditableYear"
         :variant="selectedVariant"
         :show-year="showYear"
+        :highlight-exact-date="highlightExactDate"
         :max-date="maxDate !== null ? new Date(maxDate) : null"
         :min-date="minDate !== null ? new Date(minDate) : null"
         :year-only="isYearOnly"
@@ -179,6 +190,7 @@ export default {
       selectedVariant: "default",
       selectedDate: null,
       selectedLang: "en",
+      highlightExactDate: false,
       year: 0,
       date: {
         from: null,

--- a/src/MonthPicker.vue
+++ b/src/MonthPicker.vue
@@ -21,7 +21,14 @@
         :class="{
           inactive: isInactive(month),
           clearable: clearable,
-          selected: !range && currentMonthIndex === monthIndex,
+          selected:
+            (highlightExactDate &&
+              !range &&
+              showYear &&
+              currentMonthIndex === monthIndex &&
+              year === selectedYear) ||
+            (!range && !showYear && currentMonthIndex == monthIndex) ||
+            (!highlightExactDate && !range && currentMonthIndex === monthIndex),
           'selected-range':
             range &&
             monthIndex > firstRangeMonthIndex &&
@@ -52,6 +59,7 @@ export default {
     firstRangeMonthIndex: null,
     secondRangeMonthIndex: null,
     year: new Date().getFullYear(),
+    selectedYear: new Date().getFullYear(),
   }),
   computed: {
     currentMonth: function () {
@@ -86,6 +94,7 @@ export default {
         month: this.monthsByLang[month - 1],
         monthIndex: month,
         year: this.year,
+        selectedYear: this.selectedYear,
         rangeFrom: null,
         rangeTo: null,
         rangeFromMonth: null,
@@ -117,11 +126,13 @@ export default {
     },
     defaultYear(newVal) {
       this.year = newVal;
+      this.selectedYear = newVal;
     },
   },
   mounted() {
     if (this.defaultYear) {
       this.year = this.defaultYear;
+      this.selectedYear = this.defaultYear;
     }
 
     if (this.range) {
@@ -163,6 +174,7 @@ export default {
       }
 
       this.currentMonthIndex = index;
+      this.selectedYear = this.year;
       this.onChange();
 
       if (input) {
@@ -214,6 +226,7 @@ export default {
     },
     changeYear(value) {
       this.year += value;
+
       if (this.isInactive(0)) {
         return;
       }

--- a/src/MonthPickerInput.vue
+++ b/src/MonthPickerInput.vue
@@ -16,6 +16,7 @@
       :months="months"
       :no-default="noDefault"
       :show-year="showYear"
+      :highlight-exact-date="highlightExactDate"
       :clearable="clearable"
       :variant="variant"
       :editable-year="editableYear"

--- a/src/month-picker.js
+++ b/src/month-picker.js
@@ -97,6 +97,11 @@ export default {
         return ["default", "dark"].includes(value);
       },
     },
+    highlightExactDate: {
+      type: Boolean,
+      default: false,
+      required: false,
+    },
   },
   computed: {
     monthsByLang: function () {


### PR DESCRIPTION
**highlight exact month/year combination**

Added an optional variable to allow highlighting only the month under the current selected year on the month picker layout. 

_Does not work with ranges._